### PR TITLE
fix: correct background image extension in login page CSS

### DIFF
--- a/app/static/css/login.css
+++ b/app/static/css/login.css
@@ -2,7 +2,7 @@ body {
     margin: 0;
     padding: 0;
     font-family: 'Arial', sans-serif;
-    background: url('../images/login_background.png') no-repeat center center fixed;
+    background: url('../images/login_background.jpg') no-repeat center center fixed;
     background-size: cover;
     color: white;
 }


### PR DESCRIPTION
- Updated login.css to use .jpg extension instead of incorrect .png
- Ensured login_background.jpg loads properly from static/images/
- Verified background displays correctly on /login route