### PR TITLE
Implemented share prediction via chat; update models and profile templates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -49,7 +49,7 @@ class User(db.Model, UserMixin):
     )
 
     def set_password(self, password):
-        self.password_hash = generate_password_hash(password)
+        self.password_hash = generate_password_hash(password, method='pbkdf2:sha256')
 
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -28,7 +28,7 @@
   </nav>
 
   <div class="container mt-4">
-    {% include 'profile_inner.html' %}
+    {% include 'profile_inner.html' with context %}
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/app/templates/profile_inner.html
+++ b/app/templates/profile_inner.html
@@ -79,6 +79,7 @@
             <th>Location</th>
             <th>Predicted Winner</th>
             <th>Fastest Lap</th>
+            <th>Share</th>
           </tr>
         </thead>
         <tbody>
@@ -90,6 +91,27 @@
             <td>{{ race.location }}</td>
             <td>{{ prediction.predicted_winner if prediction else "No prediction" }}</td>
             <td>{{ prediction.fastest_lap if prediction else "No prediction" }}</td>
+            <td>
+              {% if prediction %}
+              <form method="POST" action="{{ url_for('main.share_prediction') }}" class="d-flex flex-column align-items-start">
+                <input type="hidden" name="race_name" value="{{ race.raceName }}">
+                <input type="hidden" name="predicted_winner" value="{{ prediction.predicted_winner }}">
+                <input type="hidden" name="fastest_lap" value="{{ prediction.fastest_lap }}">
+              
+                <select name="friend_username" class="form-select form-select-sm mb-1" required>
+                  <option value="" disabled selected>Share with...</option>
+                  {% for friend in following %}
+                    <option value="{{ friend.username }}">{{ friend.username }}</option>
+                  {% endfor %}
+                </select>
+              
+                <button type="submit" class="btn btn-sm btn-outline-primary">Share</button>
+              </form>
+              
+              {% else %}
+                <span class="text-muted">—</span>
+              {% endif %}
+            </td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
✨ Share Prediction via Chat
This feature allows users to:

Select a friend from their following list

Share race predictions directly via the chat system

View received predictions in chat once logged in

Changes include updates to:
routes.py for backend logic
profile_inner.html to display the form
models.py if chat/message handling was adjusted